### PR TITLE
Apt cache valid time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Role Variables
 --------------
 
 - update_autoremove: Clean unused packages? (For APT distributions only)
+- update_cache_valid_time: Update the cache if it's older than the cache valid time (For APT distributions only)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,6 @@ update_down_sleep: 1
 
 # For APT (Debian/Ubuntu) only: remove unused dependency packages for all module states except `build-dep'
 update_autoremove: no
+
+# For APT (Debian/Ubuntu) only: update the apt cache if it's older than the cache_valid_time.  Set in seconds.
+update_cache_valid_time: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
   apt:
     update_cache: yes
     upgrade: dist
+    cache_valid_time: "{{ update_cache_valid_time }}"
   notify:
     - reboot
     - wait for the machine to be down


### PR DESCRIPTION
Set the update_cache_valid time.  This prevents the apt install from running an update if the cache is still valid which can save time.  The use case for this is I may want to set a reasonable value like 3600 seconds (1 hour) so that if another playbook has just refreshed the apt cache the update role is not refreshing it again unnecessarily.