### PR TITLE
Specify upgrade command type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Role Variables
 --------------
 
 - update_autoremove: Clean unused packages? (For APT distributions only)
+- update_upgrade_command: Type of upgrade: dist, yes, safe, or full.  (For APT distributions only)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,6 @@ update_down_sleep: 1
 
 # For APT (Debian/Ubuntu) only: remove unused dependency packages for all module states except `build-dep'
 update_autoremove: no
+
+# For APT (Debian/Ubuntu) only: apt_upgrade type which can be: dist, full, yes, or safe
+update_upgrade_command: dist

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: update all software (apt)
   apt:
     update_cache: yes
-    upgrade: dist
+    upgrade: "{{ update_upgrade_command }}"
   notify:
     - reboot
     - wait for the machine to be down


### PR DESCRIPTION
apt has different upgrade commands, dist, safe, full, yes (for default).  Mostly dist makes sense but sometimes safe or yes is better