### PR TITLE
chore: fix version of community.general collection in requirements.yaml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,4 @@ roles:
   - name: robertdebock.bootstrap
 collections:
   - name: community.general
+    version: 0.1.1


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
9 days ago the community.general collection was updated from 0.1.1 to 4.1.0, with it looks like breaking changes https://galaxy.ansible.com/community/general?extIdCarryOver=true&sc_cid=701f2000001OH7YAAW

With fixing the collection version, we can use update role again.

logs from my GitHub action:

```shell
$ ansible-playbook --inventory ansible-discourse-vm/environments/dev/hosts.yaml --extra-vars force_rebuild=*** --module-path  --vault-password-file /tmp/vaultPass2245403343 --private-key /tmp/privateKey637572512 --ssh-extra-args -o ConnectTimeout=600 -o ServerAliveInterval=30 ansible-discourse-vm/playbook.yaml
ERROR! couldn't resolve module/action 'community.general.apk'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in '/github/home/.ansible/roles/robertdebock.update/tasks/main.yml': line 11, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  block:
    - name: update cache (apk)
      ^ here
exit status 4
```
**Workaround**
And the version to my local requirements.yaml:

```yaml
collections:
  - name: community.general
    version: 0.1.1
```