### PR TITLE
fix: 🐛 apt autoremove condition

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
         autoremove: "{{ update_autoremove }}"
       when:
         - ansible_pkg_mgr == "apt"
-        - update_autoremove == "yes"
+        - update_autoremove | bool
   when:
     - ansible_pkg_mgr == "apt"
 


### PR DESCRIPTION
Signed-off-by: Leny1996 <8152038+Leny1996@users.noreply.github.com>

---
name: Fix for apt autoremove condition
about: ...

---

**Describe the change**
`update_autoremove` should be boolean and ansible assumes `"yes"` as string.

**Testing**
Simple debug shows how it works :)
